### PR TITLE
Offby1 most called start and most_not_called

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# starterator
+
+This is a working copy from source eddis/starterator.

--- a/starterator/phams.py
+++ b/starterator/phams.py
@@ -229,7 +229,7 @@ class Pham(object):
         for gene in self.genes.values():
             if gene.gene_id in start_stats["possible"][most_called_start_index]:
                 if gene.gene_id in genes_start_most_called:
-                    if gene.orientation == 'F':
+                    if gene.orientation == 'F':   #only +1 for forward genes
                         gene.suggested_start["most_called"] =(most_called_start_index, gene.start+1)
                     else:
                         gene.suggested_start["most_called"] =(most_called_start_index, gene.start)
@@ -237,7 +237,7 @@ class Pham(object):
                 else:
                     start_stats["most_not_called"].append(gene.gene_id)
                     most_called_alignment_index = self.total_possible_starts[most_called_start_index-1]
-                    suggested_start = gene.alignment_index_to_coord(most_called_alignment_index)+1
+                    suggested_start = gene.alignment_index_to_coord(most_called_alignment_index) #+1 issue dealt with in function
                     gene.suggested_start["most_called"] = (most_called_start_index, suggested_start)
 
             else:

--- a/starterator/phams.py
+++ b/starterator/phams.py
@@ -233,7 +233,6 @@ class Pham(object):
                         gene.suggested_start["most_called"] =(most_called_start_index, gene.start+1)
                     else:
                         gene.suggested_start["most_called"] =(most_called_start_index, gene.start)
-
                     start_stats["most_called"].append(gene.gene_id)
                 else:
                     start_stats["most_not_called"].append(gene.gene_id)

--- a/starterator/phams.py
+++ b/starterator/phams.py
@@ -229,7 +229,11 @@ class Pham(object):
         for gene in self.genes.values():
             if gene.gene_id in start_stats["possible"][most_called_start_index]:
                 if gene.gene_id in genes_start_most_called:
-                    gene.suggested_start["most_called"] =(most_called_start_index, gene.start+1)
+                    if gene.orientation == 'F':
+                        gene.suggested_start["most_called"] =(most_called_start_index, gene.start+1)
+                    else:
+                        gene.suggested_start["most_called"] =(most_called_start_index, gene.start)
+
                     start_stats["most_called"].append(gene.gene_id)
                 else:
                     start_stats["most_not_called"].append(gene.gene_id)


### PR DESCRIPTION
two minor updates to resolve some (if not all) of the "off by one" base coordinates for suggested starts. All edits in phams.py in lines 230-240 area. 
1. For genes where annotated start is "most called start" only need to add 1 to coordinate for start site on forward genes. 
2. When most called start is not "possible" the code was adding 1 inside the method `alignment_index_to_coord()` [phamgene.py line 283] and again once upon return [phams.py line 240]. Removed the +1 from phams.py 
